### PR TITLE
[libc++] Clang-trunk-friendly __libcpp_is_trivially_relocatable<T>

### DIFF
--- a/libcxx/include/CMakeLists.txt
+++ b/libcxx/include/CMakeLists.txt
@@ -591,6 +591,7 @@ set(files
   __type_traits/is_trivially_destructible.h
   __type_traits/is_trivially_move_assignable.h
   __type_traits/is_trivially_move_constructible.h
+  __type_traits/is_trivially_relocatable.h
   __type_traits/is_unbounded_array.h
   __type_traits/is_union.h
   __type_traits/is_unsigned.h

--- a/libcxx/include/__type_traits/is_trivially_relocatable.h
+++ b/libcxx/include/__type_traits/is_trivially_relocatable.h
@@ -1,0 +1,42 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCPP___TYPE_TRAITS_IS_TRIVIALLY_RELOCATABLE_H
+#define _LIBCPP___TYPE_TRAITS_IS_TRIVIALLY_RELOCATABLE_H
+
+#include <__config>
+#include <__type_traits/integral_constant.h>
+#include <__type_traits/is_trivially_destructible.h>
+#include <__type_traits/is_trivially_move_constructible.h>
+#include <__type_traits/remove_all_extents.h>
+
+#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#  pragma GCC system_header
+#endif
+
+_LIBCPP_BEGIN_NAMESPACE_STD
+
+template <class _Tp>
+struct _LIBCPP_TEMPLATE_VIS __libcpp_is_trivially_relocatable
+  : public integral_constant<bool,
+#if __has_extension(trivially_relocatable)
+      __is_trivially_relocatable(_Tp)
+#else
+      is_trivially_move_constructible<typename remove_all_extents<_Tp>::type>::value &&
+      is_trivially_destructible<typename remove_all_extents<_Tp>::type>::value
+#endif
+  > {};
+
+#if _LIBCPP_STD_VER > 14
+template <class _Tp>
+inline constexpr bool __libcpp_is_trivially_relocatable_v = __libcpp_is_trivially_relocatable<_Tp>::value;
+#endif
+
+_LIBCPP_END_NAMESPACE_STD
+
+#endif // _LIBCPP___TYPE_TRAITS_IS_TRIVIALLY_RELOCATABLE_H

--- a/libcxx/include/module.modulemap.in
+++ b/libcxx/include/module.modulemap.in
@@ -1176,6 +1176,7 @@ module std [system] {
     module is_trivially_destructible          { private header "__type_traits/is_trivially_destructible.h" }
     module is_trivially_move_assignable       { private header "__type_traits/is_trivially_move_assignable.h" }
     module is_trivially_move_constructible    { private header "__type_traits/is_trivially_move_constructible.h" }
+    module is_trivially_relocatable           { private header "__type_traits/is_trivially_relocatable.h" }
     module is_unbounded_array                 { private header "__type_traits/is_unbounded_array.h" }
     module is_union                           { private header "__type_traits/is_union.h" }
     module is_unsigned                        { private header "__type_traits/is_unsigned.h" }

--- a/libcxx/include/type_traits
+++ b/libcxx/include/type_traits
@@ -503,6 +503,7 @@ namespace std
 #include <__type_traits/is_trivially_destructible.h>
 #include <__type_traits/is_trivially_move_assignable.h>
 #include <__type_traits/is_trivially_move_constructible.h>
+#include <__type_traits/is_trivially_relocatable.h>
 #include <__type_traits/is_unbounded_array.h>
 #include <__type_traits/is_union.h>
 #include <__type_traits/is_unsigned.h>

--- a/libcxx/test/libcxx/private_headers.verify.cpp
+++ b/libcxx/test/libcxx/private_headers.verify.cpp
@@ -603,6 +603,7 @@ END-SCRIPT
 #include <__type_traits/is_trivially_destructible.h> // expected-error@*:* {{use of private header from outside its module: '__type_traits/is_trivially_destructible.h'}}
 #include <__type_traits/is_trivially_move_assignable.h> // expected-error@*:* {{use of private header from outside its module: '__type_traits/is_trivially_move_assignable.h'}}
 #include <__type_traits/is_trivially_move_constructible.h> // expected-error@*:* {{use of private header from outside its module: '__type_traits/is_trivially_move_constructible.h'}}
+#include <__type_traits/is_trivially_relocatable.h> // expected-error@*:* {{use of private header from outside its module: '__type_traits/is_trivially_relocatable.h'}}
 #include <__type_traits/is_unbounded_array.h> // expected-error@*:* {{use of private header from outside its module: '__type_traits/is_unbounded_array.h'}}
 #include <__type_traits/is_union.h> // expected-error@*:* {{use of private header from outside its module: '__type_traits/is_union.h'}}
 #include <__type_traits/is_unsigned.h> // expected-error@*:* {{use of private header from outside its module: '__type_traits/is_unsigned.h'}}

--- a/libcxx/test/libcxx/utilities/meta/meta.unary/meta.unary.prop/is_trivially_relocatable.pass.cpp
+++ b/libcxx/test/libcxx/utilities/meta/meta.unary/meta.unary.prop/is_trivially_relocatable.pass.cpp
@@ -1,0 +1,103 @@
+//===----------------------------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// type_traits
+
+// __libcpp_is_trivially_relocatable
+// __libcpp_is_trivially_relocatable_v
+
+#include <memory>
+#include <type_traits>
+#include "test_macros.h"
+
+
+template <class T>
+void test_is_trivially_relocatable()
+{
+    static_assert(std::__libcpp_is_trivially_relocatable<T>::value, "");
+#if TEST_STD_VER > 14
+    static_assert(std::__libcpp_is_trivially_relocatable_v<T>, "");
+#endif
+}
+
+template <class T>
+void test_is_not_trivially_relocatable()
+{
+    static_assert(!std::__libcpp_is_trivially_relocatable<T>::value, "");
+#if TEST_STD_VER > 14
+    static_assert(!std::__libcpp_is_trivially_relocatable_v<T>, "");
+#endif
+}
+
+class Empty {};
+
+class Abstract {
+public:
+  virtual ~Abstract() = 0;
+};
+
+class Polymorphic {
+public:
+  virtual ~Polymorphic() = default;
+};
+
+union Union {};
+
+struct bit_zero {
+  int : 0;
+};
+
+struct CopyCtor {
+  CopyCtor(const CopyCtor&);
+};
+
+#if TEST_STD_VER >= 11
+struct MoveOnly1 {
+  MoveOnly1(MoveOnly1&&);
+};
+
+struct MoveOnly2 {
+  MoveOnly2(MoveOnly2&&) = default;
+};
+#endif
+
+int main(int, char**)
+{
+    test_is_not_trivially_relocatable<void>();
+    test_is_not_trivially_relocatable<const void>();
+    test_is_not_trivially_relocatable<Abstract>();
+    test_is_not_trivially_relocatable<Polymorphic>();
+    test_is_not_trivially_relocatable<CopyCtor>();
+
+    test_is_trivially_relocatable<Union>();
+    test_is_trivially_relocatable<Empty>();
+    test_is_trivially_relocatable<double>();
+    test_is_trivially_relocatable<int*>();
+    test_is_trivially_relocatable<const int*>();
+    test_is_trivially_relocatable<bit_zero>();
+
+    test_is_trivially_relocatable<int>();
+    test_is_trivially_relocatable<const int>();
+    test_is_trivially_relocatable<volatile int>();
+    test_is_trivially_relocatable<const volatile int>();
+
+    test_is_trivially_relocatable<int[]>();
+    test_is_trivially_relocatable<int[10]>();
+    test_is_trivially_relocatable<int[][2]>();
+    test_is_trivially_relocatable<int[1][2]>();
+
+#if TEST_STD_VER >= 11
+    test_is_not_trivially_relocatable<MoveOnly1>();
+    test_is_not_trivially_relocatable<const MoveOnly1>();
+    test_is_trivially_relocatable<MoveOnly2>();
+    test_is_trivially_relocatable<const MoveOnly2>();
+#endif
+
+    return 0;
+}


### PR DESCRIPTION
This is not a fully P1144-compliant implementation on Clang trunk; Clang trunk's builtin `__is_trivially_relocatable(T)` gets at least the following cases wrong: https://p1144.godbolt.org/z/MhncMxrdj

However, this patch will minimize the diffs between libc++ trunk and libc++ P1144-branch.